### PR TITLE
Feat: cocoapod support

### DIFF
--- a/WorkManager.podspec
+++ b/WorkManager.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   
   s.author           = "Gojek"
-  s.source           = { :git => 'https://github.com/gojek/WorkManager.git' }
+  s.source           = { :git => 'https://github.com/gojek/WorkManager.git', :tag => '#{s.version}' }
 
   s.platform         = :ios
   s.ios.deployment_target = '11.0'

--- a/WorkManager.podspec
+++ b/WorkManager.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   
   s.author           = "Gojek"
-  s.source           = { :git => '' }
+  s.source           = { :git => 'https://github.com/gojek/WorkManager.git' }
 
   s.platform         = :ios
   s.ios.deployment_target = '11.0'


### PR DESCRIPTION
## Description

This is created towards consecutive efforts for adding support of Cocoapod-based distribution of this library

## Motivation and Context

Cocoapod being one of the most popular dependency management mechanisms in the iOS Dev ecosystem, it is a must that **WorkManager** also supports it, it solved the problem for users using cocoapod as their dependency management system whom were not able to use the library.

## How Has This Been Tested?

We have tested the implementation of the podspec by running the below command

`pod spec lint`

In addition to that, we have integrated the resulting pod into a POC iOS App.

## Screenshots (if appropriate)

Not Applicable

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
